### PR TITLE
Suggestion: configure.sh shouldn't install Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,28 @@ The post-TOGA processing pipeline.
 
 ## Usage
 
-To use postoga, just do:
+To use postoga, just:
 
+Clone the repository
 ```bash
 # clone the repository
 git clone --recursive https://github.com/alejandrogzi/postoga.git
 cd postoga
+```
 
-# create an environment (recommended)
+Create a conda environment (recommended) OR set INSTALL_PYTHON in configure.sh to true
+```bash
 conda env create -f env.yml
 conda activate postoga
+```
 
-# OR call configure.sh to install dependencies
+Run configure.sh to install dependencies (Rust required)
+```bash
 ./configure.sh
+```
 
-# run a test to confirm functionality
+Run test to confirm functionality
+```bash
 ./test.sh
 ```
 


### PR DESCRIPTION
Right now configure.sh automatically installs Rust if it isn't there, adds a line to .bashrc, and installs python dependencies. It also doesn't install noel if GET_BINARIES is false


This pull request:
1. Modifies configure.sh to just tell the user to install Rust themselves.
2. Removes the modification to $PATH since the rust installation already does that
3. Changes INSTALL_PYTHON to false because you recommended using a conda environment
4. Adds noel to the submodule installations