### PR TITLE
Fix type errors for python <=3.9

### DIFF
--- a/modules/assembly_stats.py
+++ b/modules/assembly_stats.py
@@ -16,6 +16,7 @@ import pandas as pd
 from constants import Constants
 from logger import Log
 from modules.utils import bed_reader, ancestral_reader
+from typing import Union
 
 
 __author__ = "Alejandro Gonzales-Irribarren"
@@ -24,7 +25,7 @@ __github__ = "https://github.com/alejandrogzi"
 __version__ = "0.7.0-devel"
 
 
-def get_classes(outdir: str | os.PathLike, bed: str, table: pd.DataFrame) -> pd.DataFrame:
+def get_classes(outdir: Union[str, os.PathLike], bed: str, table: pd.DataFrame) -> pd.DataFrame:
     """
     @type outdir: str | os.PathLike
     @param outdir: path to output directory
@@ -49,7 +50,7 @@ def get_classes(outdir: str | os.PathLike, bed: str, table: pd.DataFrame) -> pd.
 
 
 def qual_by_ancestral(
-    outdir: str | os.PathLike, bed: str, table: pd.DataFrame, assembly_qual: str, source: str
+    outdir: Union[str, os.PathLike], bed: str, table: pd.DataFrame, assembly_qual: str, source: str
 ) -> None:
     """
     @type outdir: str | os.PathLike
@@ -77,7 +78,7 @@ def qual_by_ancestral(
     return stats
 
 
-def overlap_busco(outdir: str | os.PathLike, db: str, table: pd.DataFrame, src: str) -> float:
+def overlap_busco(outdir: Union[str, os.PathLike], db: str, table: pd.DataFrame, src: str) -> float:
     """
     @type outdir: str | os.PathLike
     @param outdir: path to output directory
@@ -105,7 +106,7 @@ def overlap_busco(outdir: str | os.PathLike, db: str, table: pd.DataFrame, src: 
     return track
 
 
-def busco_completeness(outdir: str | os.PathLike, table: pd.DataFrame, src: str, phylo: str) -> list:
+def busco_completeness(outdir: Union[str, os.PathLike], table: pd.DataFrame, src: str, phylo: str) -> list:
     """
     @type outdir: str | os.PathLike
     @param outdir: path to output directory

--- a/modules/convert_from_bed.py
+++ b/modules/convert_from_bed.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-
 """ A module to convert .bed files to .gtf and .gff files. """
 
 
@@ -8,6 +7,7 @@ import os
 from constants import Constants
 from logger import Log
 from modules.utils import shell
+from typing import Union
 
 
 __author__ = "Alejandro Gonzales-Irribarren"
@@ -16,7 +16,7 @@ __github__ = "https://github.com/alejandrogzi"
 __version__ = "0.6.0-devel"
 
 
-def bed_to_gtf(outdir: str | os.PathLike, bed: str, isoforms: str) -> str:
+def bed_to_gtf(outdir: Union[str, os.PathLike], bed: str, isoforms: str) -> str:
     """
     Converts a .bed file to .gtf
 
@@ -45,7 +45,7 @@ def bed_to_gtf(outdir: str | os.PathLike, bed: str, isoforms: str) -> str:
     return gtf
 
 
-def bed_to_gff(outdir: str | os.PathLike, bed: str, isoforms: str) -> str:
+def bed_to_gff(outdir: Union[str, os.PathLike], bed: str, isoforms: str) -> str:
     """
     Converts a .bed file to .gff
 

--- a/modules/filter_query_annotation.py
+++ b/modules/filter_query_annotation.py
@@ -9,6 +9,7 @@ import os
 from constants import Constants
 from logger import Log
 from modules.utils import bed_reader
+from typing import Union
 
 
 __author__ = "Alejandro Gonzales-Irribarren"
@@ -18,7 +19,7 @@ __version__ = "0.8.0-devel"
 
 
 def filter_bed(
-    togadir: str | os.PathLike, outdir: str | os.PathLike, table: pd.DataFrame, by_class: list, by_rel: list, threshold: float, paralog: float
+    togadir: Union[str, os.PathLike], outdir: Union[str, os.PathLike], table: pd.DataFrame, by_class: list, by_rel: list, threshold: float, paralog: float
     ) -> tuple:
     """
     Filters the original .bed file to produce a custom filtered file

--- a/modules/ortholog_lengths.py
+++ b/modules/ortholog_lengths.py
@@ -5,6 +5,8 @@ from modules.utils import shell
 import pandas as pd
 from constants import Constants
 from logger import Log
+from typing import Union
+
 
 __author__ = "Alejandro Gonzales-Irribarren"
 __email__ = "jose.gonzalesdezavala1@unmsm.edu.pe"
@@ -12,7 +14,7 @@ __github__ = "https://github.com/alejandrogzi"
 __version__ = "0.7.0-devel"
 
 
-def noel_lengths(outdir: str | os.PathLike, model: str) -> str:
+def noel_lengths(outdir: Union[str, os.PathLike], model: str) -> str:
     """
     Calculate the distribution of ortholog lengths in the resulting gtf/gff file using NOEL.
 
@@ -41,7 +43,7 @@ def noel_lengths(outdir: str | os.PathLike, model: str) -> str:
     return lengths
 
 
-def process_lenghts(outdir: str | os.PathLike, lengths: str) -> pd.Series:
+def process_lenghts(outdir: Union[str, os.PathLike], lengths: str) -> pd.Series:
     """
     Processes the lengths file to get the ortholog lengths.
 
@@ -71,7 +73,7 @@ def process_lenghts(outdir: str | os.PathLike, lengths: str) -> pd.Series:
     return df["lengths"]
 
 
-def calculate_lengths(outdir: str | os.PathLike, model: str) -> pd.Series:
+def calculate_lengths(outdir: Union[str, os.PathLike], model: str) -> pd.Series:
     """
     Calculate the distribution of ortholog lengths in the resulting gtf/gff file.
 

--- a/modules/write_isoforms.py
+++ b/modules/write_isoforms.py
@@ -8,8 +8,10 @@ import pandas as pd
 import os
 from constants import Constants
 from logger import Log
+from typing import Union
 
 pd.options.mode.chained_assignment = None  # default='warn'
+
 
 __author__ = "Alejandro Gonzales-Irribarren"
 __email__ = "jose.gonzalesdezavala1@unmsm.edu.pe"
@@ -17,7 +19,7 @@ __github__ = "https://github.com/alejandrogzi"
 __version__ = "0.7.0-devel"
 
 
-def isoform_writer(outdir: str | os.PathLike, table: pd.DataFrame) -> str:
+def isoform_writer(outdir: Union[str, os.PathLike], table: pd.DataFrame) -> str:
     """
     Writes all isoforms to a text file
 


### PR DESCRIPTION
Thank you for the clean software! It was easy to debug :)

For users on python `<= 3.9`, postoga throws what looks like a TypeError during the test and during actual runs.

This is because the shorthand notation `|` for type unions currently used herein is only supported in `python >= 3.10`. This PR replaces that shorthand with `typing.Union` which is supported for python `<= 3.9` (I think `>=3.5`, `<=3.9`)?

```
(postoga) [0/14:40] e0175719@ln-vm-02:~/repos/postoga $ hatch run test
Traceback (most recent call last):
File "/data/wanglf/home/e0175719/repos/postoga/./postoga.py", line 19, in <module>
from modules.convert_from_bed import bed_to_gtf, bed_to_gff
  File "/data/wanglf/home/e0175719/repos/postoga/modules/convert_from_bed.py", line 19, in <module>
    def bed_to_gtf(outdir: str | os.PathLike, bed: str, isoforms: str) -> str:
TypeError: unsupported operand type(s) for |: 'type' and 'ABCMeta'
Test completed!
head: cannot open './test_out/postoga.log' for reading: No such file or directory                       
```